### PR TITLE
Pass the encoding to the parent write()

### DIFF
--- a/lib/deflate-crc32-stream.js
+++ b/lib/deflate-crc32-stream.js
@@ -39,13 +39,13 @@ DeflateCRC32Stream.prototype.push = function(chunk, encoding) {
   return zlib.DeflateRaw.prototype.push.call(this, chunk, encoding);
 };
 
-DeflateCRC32Stream.prototype.write = function(chunk, cb) {
+DeflateCRC32Stream.prototype.write = function(chunk, enc, cb) {
   if (chunk) {
     this.checksum = crc32(chunk, this.checksum);
     this.rawSize += chunk.length;
   }
 
-  return zlib.DeflateRaw.prototype.write.call(this, chunk, cb);
+  return zlib.DeflateRaw.prototype.write.call(this, chunk, enc, cb);
 };
 
 DeflateCRC32Stream.prototype.digest = function() {


### PR DESCRIPTION
Not doing this breaks some usecases.