### PR TITLE
Switch to node-crc for better performance

### DIFF
--- a/lib/crc32-stream.js
+++ b/lib/crc32-stream.js
@@ -8,7 +8,7 @@
 var inherits = require('util').inherits;
 var Transform = require('readable-stream').Transform;
 
-var crc32 = require('buffer-crc32');
+var crc32 = require('crc').crc32;
 
 var CRC32Stream = module.exports = function CRC32Stream(options) {
   Transform.call(this, options);
@@ -30,7 +30,7 @@ CRC32Stream.prototype._transform = function(chunk, encoding, callback) {
 };
 
 CRC32Stream.prototype.digest = function() {
-  return crc32.unsigned(0, this.checksum);
+  return this.checksum >>> 0;
 };
 
 CRC32Stream.prototype.hex = function() {

--- a/lib/deflate-crc32-stream.js
+++ b/lib/deflate-crc32-stream.js
@@ -8,7 +8,7 @@
 var zlib = require('zlib');
 var inherits = require('util').inherits;
 
-var crc32 = require('buffer-crc32');
+var crc32 = require('crc').crc32;
 
 var DeflateCRC32Stream = module.exports = function (options) {
   zlib.DeflateRaw.call(this, options);
@@ -49,7 +49,7 @@ DeflateCRC32Stream.prototype.write = function(chunk, enc, cb) {
 };
 
 DeflateCRC32Stream.prototype.digest = function() {
-  return crc32.unsigned(0, this.checksum);
+  return this.checksum >>> 0;
 };
 
 DeflateCRC32Stream.prototype.hex = function() {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "test": "mocha --reporter dot"
   },
   "dependencies": {
-    "readable-stream": "^2.0.0",
-    "buffer-crc32": "^0.2.1"
+    "crc": "^3.4.4",
+    "readable-stream": "^2.0.0"
   },
   "devDependencies": {
     "chai": "^3.4.0",


### PR DESCRIPTION
buffer-crc32 is substantially slower than [node-crc](https://github.com/alexgorbatchev/node-crc) because it converts the CRC itself to and from a length-1 buffer on every update. In a benchmark with `crc32stream.write(<a 2 MB buffer>)` (single invocation of the CRC function), node-crc is 10 ms / 37% faster than buffer-crc32. In another benchmark writing a 1KB buffer 1000x, node-crc was 62% faster.