### PR TITLE
Adopt node core's Hash API

### DIFF
--- a/lib/crc32-stream.js
+++ b/lib/crc32-stream.js
@@ -29,12 +29,14 @@ CRC32Stream.prototype._transform = function(chunk, encoding, callback) {
   callback(null, chunk);
 };
 
-CRC32Stream.prototype.digest = function() {
-  return this.checksum >>> 0;
+CRC32Stream.prototype.digest = function(encoding) {
+  var checksum = new Buffer(4);
+  checksum.writeUInt32BE(this.checksum >>> 0, 0);
+  return encoding ? checksum.toString(encoding) : checksum;
 };
 
 CRC32Stream.prototype.hex = function() {
-  return this.digest().toString(16).toUpperCase();
+  return this.digest('hex').toUpperCase();
 };
 
 CRC32Stream.prototype.size = function() {

--- a/lib/deflate-crc32-stream.js
+++ b/lib/deflate-crc32-stream.js
@@ -48,12 +48,14 @@ DeflateCRC32Stream.prototype.write = function(chunk, enc, cb) {
   return zlib.DeflateRaw.prototype.write.call(this, chunk, enc, cb);
 };
 
-DeflateCRC32Stream.prototype.digest = function() {
-  return this.checksum >>> 0;
+DeflateCRC32Stream.prototype.digest = function(encoding) {
+  var checksum = new Buffer(4);
+  checksum.writeUInt32BE(this.checksum >>> 0, 0);
+  return encoding ? checksum.toString(encoding) : checksum;
 };
 
 DeflateCRC32Stream.prototype.hex = function() {
-  return this.digest().toString(16).toUpperCase();
+  return this.digest('hex').toUpperCase();
 };
 
 DeflateCRC32Stream.prototype.size = function(compressed) {

--- a/test/checksum.js
+++ b/test/checksum.js
@@ -14,7 +14,8 @@ describe('CRC32Stream', function() {
     var deadend = new DeadEndStream();
 
     checksum.on('end', function() {
-      assert.equal(checksum.digest(), 3893830384);
+      assert.equal(checksum.digest().readUInt32BE(0), 3893830384);
+      assert.equal(checksum.digest('hex'), 'e81722f0');
       assert.equal(checksum.hex(), 'E81722F0');
       assert.equal(checksum.size(), 16384);
       done();
@@ -29,7 +30,7 @@ describe('CRC32Stream', function() {
     var deadend = new DeadEndStream();
 
     checksum.on('end', function() {
-      assert.equal(checksum.digest(), 0);
+      assert.equal(checksum.digest().readUInt32BE(0), 0);
       done();
     });
 

--- a/test/deflate.js
+++ b/test/deflate.js
@@ -14,7 +14,8 @@ describe('DeflateCRC32Stream', function() {
     var deadend = new DeadEndStream();
 
     checksum.on('end', function() {
-      assert.equal(checksum.digest(), 3893830384);
+      assert.equal(checksum.digest().readUInt32BE(0), 3893830384);
+      assert.equal(checksum.digest('hex'), 'e81722f0');
       assert.equal(checksum.hex(), 'E81722F0');
       assert.equal(checksum.size(), 16384);
       assert.equal(checksum.size(true), 402);
@@ -30,7 +31,7 @@ describe('DeflateCRC32Stream', function() {
     var deadend = new DeadEndStream();
 
     checksum.on('end', function() {
-      assert.equal(checksum.digest(), 0);
+      assert.equal(checksum.digest().readUInt32BE(0), 0);
       done();
     });
 


### PR DESCRIPTION
This changes the `.digest()` API to behave the same way as Node's `crypto.Hash` streams, to enable use as a drop-in without having to write additional code handling the digest of this library.

**Changes:**
- Add `encoding` argument to `.digest()`, to mirror node's `crypto.Hash` API

**Breaking change:**
- `.digest()` now returns a `Buffer` by default, instead of a `Number`