### PR TITLE
Work around issue in Node.js 8.0.0

### DIFF
--- a/lib/deflate-crc32-stream.js
+++ b/lib/deflate-crc32-stream.js
@@ -6,12 +6,14 @@
  * https://github.com/archiverjs/node-crc32-stream/blob/master/LICENSE-MIT
  */
 var zlib = require('zlib');
+var extend = Object.assign || require('util')._extend
 var inherits = require('util').inherits;
 
 var crc32 = require('crc').crc32;
 
 var DeflateCRC32Stream = module.exports = function (options) {
-  zlib.DeflateRaw.call(this, options);
+  var stream = zlib.DeflateRaw.call(this, options);
+  if (stream) extend(this, stream)
 
   this.checksum = new Buffer(4);
   this.checksum.writeInt32BE(0, 0);


### PR DESCRIPTION
This works around the issue in Node.js 8.0.0 where `zlib.DeflateRaw`'s constructor returns an object rather than mutating `this`.

Fixes: #5