### PR TITLE
Do not use the deprecated Buffer() constructor

### DIFF
--- a/lib/crc32-stream.js
+++ b/lib/crc32-stream.js
@@ -12,7 +12,7 @@ var crc32 = require('crc').crc32;
 
 var CRC32Stream = module.exports = function CRC32Stream(options) {
   Transform.call(this, options);
-  this.checksum = new Buffer(4);
+  this.checksum = Buffer.allocUnsafe(4);
   this.checksum.writeInt32BE(0, 0);
 
   this.rawSize = 0;
@@ -30,7 +30,7 @@ CRC32Stream.prototype._transform = function(chunk, encoding, callback) {
 };
 
 CRC32Stream.prototype.digest = function(encoding) {
-  var checksum = new Buffer(4);
+  var checksum = Buffer.allocUnsafe(4);
   checksum.writeUInt32BE(this.checksum >>> 0, 0);
   return encoding ? checksum.toString(encoding) : checksum;
 };

--- a/lib/deflate-crc32-stream.js
+++ b/lib/deflate-crc32-stream.js
@@ -13,7 +13,7 @@ var crc32 = require('crc').crc32;
 var DeflateCRC32Stream = module.exports = function (options) {
   zlib.DeflateRaw.call(this, options);
 
-  this.checksum = new Buffer(4);
+  this.checksum = Buffer.allocUnsafe(4);
   this.checksum.writeInt32BE(0, 0);
 
   this.rawSize = 0;
@@ -49,7 +49,7 @@ DeflateCRC32Stream.prototype.write = function(chunk, enc, cb) {
 };
 
 DeflateCRC32Stream.prototype.digest = function(encoding) {
-  var checksum = new Buffer(4);
+  var checksum = Buffer.allocUnsafe(4);
   checksum.writeUInt32BE(this.checksum >>> 0, 0);
   return encoding ? checksum.toString(encoding) : checksum;
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lib"
   ],
   "engines": {
-    "node": ">= 4"
+    "node": ">= 4.5.0"
   },
   "scripts": {
     "test": "mocha --reporter dot"

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -21,7 +21,7 @@ function adjustDateByOffset(d, offset) {
 module.exports.adjustDateByOffset = adjustDateByOffset;
 
 function binaryBuffer(n) {
-  var buffer = new Buffer(n);
+  var buffer = Buffer.allocUnsafe(n);
 
   for (var i = 0; i < n; i++) {
     buffer.writeUInt8(i&255, i);
@@ -35,7 +35,7 @@ module.exports.binaryBuffer = binaryBuffer;
 function BinaryStream(size, options) {
   Readable.call(this, options);
 
-  var buf = new Buffer(size);
+  var buf = Buffer.allocUnsafe(size);
 
   for (var i = 0; i < size; i++) {
     buf.writeUInt8(i&255, i);


### PR DESCRIPTION
Refs: https://github.com/nodejs/citgm/issues/605
Refs: https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor