### PR TITLE
Issue 27: use crc-32 rather than crc because it works when seed=0

### DIFF
--- a/lib/crc32-stream.js
+++ b/lib/crc32-stream.js
@@ -10,7 +10,7 @@
 
 const {Transform} = require('readable-stream');
 
-const {crc32} = require('crc');
+const crc32 = require('crc-32');
 
 class CRC32Stream extends Transform {
   constructor(options) {
@@ -23,7 +23,7 @@ class CRC32Stream extends Transform {
 
   _transform(chunk, encoding, callback) {
     if (chunk) {
-      this.checksum = crc32(chunk, this.checksum);
+      this.checksum = crc32.buf(chunk, this.checksum) >>> 0;
       this.rawSize += chunk.length;
     }
 

--- a/lib/deflate-crc32-stream.js
+++ b/lib/deflate-crc32-stream.js
@@ -10,7 +10,7 @@
 
 const {DeflateRaw} = require('zlib');
 
-const {crc32} = require('crc');
+const crc32 = require('crc-32');
 
 class DeflateCRC32Stream extends DeflateRaw {
   constructor(options) {
@@ -33,7 +33,7 @@ class DeflateCRC32Stream extends DeflateRaw {
 
   write(chunk, enc, cb) {
     if (chunk) {
-      this.checksum = crc32(chunk, this.checksum);
+      this.checksum = crc32.buf(chunk, this.checksum) >>> 0;
       this.rawSize += chunk.length;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,11 +62,6 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "base64-js": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
-    },
     "binary-extensions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
@@ -98,15 +93,6 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
-    "buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
-      "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
-      "requires": {
-        "base64-js": "1.3.0",
-        "ieee754": "1.1.13"
-      }
-    },
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -119,12 +105,12 @@
       "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
       "dev": true,
       "requires": {
-        "assertion-error": "1.1.0",
-        "check-error": "1.0.2",
-        "deep-eql": "3.0.1",
-        "get-func-name": "2.0.0",
-        "pathval": "1.1.0",
-        "type-detect": "4.0.8"
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
       }
     },
     "chalk": {
@@ -219,12 +205,13 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "crc": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
-      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+    "crc-32": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz",
+      "integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
       "requires": {
-        "buffer": "5.2.1"
+        "exit-on-epipe": "~1.0.1",
+        "printj": "~1.1.0"
       }
     },
     "debug": {
@@ -248,7 +235,7 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "4.0.8"
+        "type-detect": "^4.0.0"
       }
     },
     "diff": {
@@ -274,6 +261,11 @@
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
+    },
+    "exit-on-epipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
+      "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw=="
     },
     "fill-range": {
       "version": "7.0.1",
@@ -365,11 +357,6 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
-    },
-    "ieee754": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -578,6 +565,11 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
+    },
+    "printj": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
+      "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ=="
     },
     "randombytes": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "mocha --reporter dot"
   },
   "dependencies": {
-    "crc": "^3.4.4",
+    "crc-32": "^1.2.0",
     "readable-stream": "^3.4.0"
   },
   "devDependencies": {

--- a/test/checksum.js
+++ b/test/checksum.js
@@ -3,6 +3,7 @@
 'use strict';
 
 const {assert} = require('chai');
+const crc32 = require('crc-32');
 
 const {BinaryStream, DeadEndStream} = require('./helpers');
 
@@ -24,6 +25,23 @@ describe('CRC32Stream', function() {
 
     checksum.pipe(deadend);
     binary.pipe(checksum);
+  });
+  
+  it('should have same checksum when bytes written together or separately', function(done) {
+    const checksum = new CRC32Stream();
+    const deadend = new DeadEndStream();
+    
+    const expectedChecksumValue = crc32.buf([157, 10, 217, 109, 100, 200, 300]) >>> 0;
+
+    checksum.on('end', function() {
+      assert.equal(checksum.digest().readUInt32BE(0), expectedChecksumValue);
+      done();
+    });
+    
+    checksum.write(Buffer.from([157, 10, 217, 109]));
+    checksum.write(Buffer.from([100, 200, 300]));
+    checksum.end();
+    checksum.pipe(deadend);
   });
 
   it('should gracefully handle having no data chunks passed to it', function(done) {


### PR DESCRIPTION
* Fixes [Issue 27](https://github.com/archiverjs/node-crc32-stream/issues/27).
* The [crc module has a defect](https://github.com/alexgorbatchev/node-crc/issues/66) where it computes an incorrect checksum if the seed checksum value is `0`.  `0` is a legitimate checksum value, but that module handles it incorrectly.
* This change switches to using [crc-32](https://www.npmjs.com/package/crc-32) instead.
* New regression unit tests are added.