### PR TITLE
fix DeflateCRC32Stream to support Node.js 15.6.0+ (#31)

### DIFF
--- a/lib/deflate-crc32-stream.js
+++ b/lib/deflate-crc32-stream.js
@@ -31,13 +31,13 @@ class DeflateCRC32Stream extends DeflateRaw {
     return super.push(chunk, encoding);
   }
 
-  write(chunk, enc, cb) {
+  _transform(chunk, encoding, callback) {
     if (chunk) {
       this.checksum = crc32.buf(chunk, this.checksum) >>> 0;
       this.rawSize += chunk.length;
     }
 
-    return super.write(chunk, enc, cb);
+    super._transform(chunk, encoding, callback)
   }
 
   digest(encoding) {


### PR DESCRIPTION
Since the Node.js behavior will be rollbacked only in 15.x branch, the problem will appear again in 16.x+
Fixed tested with 15.5.1 and 15.6.0